### PR TITLE
implemented exclude_abstract in discover_classes

### DIFF
--- a/tests/test_discover_classes.py
+++ b/tests/test_discover_classes.py
@@ -1,6 +1,8 @@
 import sys
+from abc import ABC
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 
 from barentsz import discover_classes
 
@@ -94,3 +96,20 @@ class TestDiscoverClasses(TestCase):
         self.assertIn(Class1_level2, classes1)
         self.assertEqual(1, len(classes2))
         self.assertIn(Class1_level2, classes2)
+
+    @patch('barentsz._discover._discover_elements')
+    def test_discover_classes_exclude_abstract(self, mock_discover_elements: MagicMock):
+        # SETUP
+        class MyClass:
+            ...
+
+        class MyAbstractClass(ABC):
+            ...
+
+        mock_discover_elements.return_value = [MyClass, MyAbstractClass]
+
+        # EXECUTE
+        classes = discover_classes(None, exclude_abstract=True)
+
+        # VERIFY
+        self.assertEqual([MyClass], classes)


### PR DESCRIPTION
Closes #2 

Straightforward implementation for excluding abstract classes in discovery.

There seems to be some disagreement as to what exactly determines if a class is abstract. I've put a suggestion for this definition in the `_is_abstract(cls: type) -> bool` function, so it can be easily changed if you have a different proposal.